### PR TITLE
Allow rails dev tweaks to continue tweaking asset requests when action_controller caching is enabled

### DIFF
--- a/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
+++ b/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
@@ -22,7 +22,7 @@ class RailsDevTweaks::GranularAutoload::Matchers::AssetMatcher
     end
 
     # what do we have?
-    main_mount.kind_of? Sprockets::Environment
+    main_mount.kind_of? Sprockets::Base
   end
 
 end


### PR DESCRIPTION
This patch matches both Sprockets::Environment and Sprockets::Index which is switched in when action_controller.caching is enabled in the development environment.

Without this, things slow to a crawl again. :)
