### PR TITLE
Fix for issue #3

### DIFF
--- a/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
+++ b/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
@@ -1,7 +1,7 @@
 class RailsDevTweaks::GranularAutoload::Matchers::AssetMatcher
 
   def call(request)
-    main_mount = request.headers['action_dispatch.routes'].set.recognize(request)
+    main_mount = request.headers['action_dispatch.routes'].set.dup.recognize(request)
 
     # Unwind until we have an actual app
     while main_mount != nil


### PR DESCRIPTION
Fix for params set by overriding `recognize` being lost when determining whether to reload [#3]
