### PR TITLE
Fix for AssetMatcher to work with Rails 3.2.0

### DIFF
--- a/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
+++ b/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
@@ -5,6 +5,7 @@ class RailsDevTweaks::GranularAutoload::Matchers::AssetMatcher
       request.headers['action_dispatch.routes'].router.recognize(request) do |route|
         return true if route.app.is_a?(Sprockets::Base)
       end
+      false
     end
   else
     def call(request)

--- a/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
+++ b/lib/rails_dev_tweaks/granular_autoload/matchers/asset_matcher.rb
@@ -1,28 +1,36 @@
 class RailsDevTweaks::GranularAutoload::Matchers::AssetMatcher
 
-  def call(request)
-    main_mount = request.headers['action_dispatch.routes'].set.dup.recognize(request)
-
-    # Unwind until we have an actual app
-    while main_mount != nil
-      if main_mount.kind_of? Array
-        main_mount = main_mount.first
-
-      elsif main_mount.kind_of? Rack::Mount::Route
-        main_mount = main_mount.app
-
-      elsif main_mount.kind_of? Rack::Mount::Prefix
-        # Bah, no accessor here
-        main_mount = main_mount.instance_variable_get(:@app)
-
-      # Well, we got something
-      else
-        break
+  if Rails::VERSION::STRING >= '3.2.0'
+    def call(request)
+      request.headers['action_dispatch.routes'].router.recognize(request) do |route|
+        return true if route.app.is_a?(Sprockets::Base)
       end
     end
-
-    # what do we have?
-    main_mount.kind_of? Sprockets::Base
+  else
+    def call(request)
+      main_mount = request.headers['action_dispatch.routes'].set.dup.recognize(request)
+      
+      # Unwind until we have an actual app
+      while main_mount != nil
+        if main_mount.kind_of? Array
+          main_mount = main_mount.first
+          
+        elsif main_mount.kind_of? Rack::Mount::Route
+          main_mount = main_mount.app
+          
+        elsif main_mount.kind_of? Rack::Mount::Prefix
+          # Bah, no accessor here
+          main_mount = main_mount.instance_variable_get(:@app)
+          
+          # Well, we got something
+        else
+          break
+        end
+      end
+      
+      # what do we have?
+      main_mount.kind_of? Sprockets::Base
+    end
   end
 
 end


### PR DESCRIPTION
Updated the AssetMatcher logic to work with new Journey routing when operating under Rails 3.2.0.
