### PR TITLE
Remove xhr from default conf in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ The default autoload rules should cover most development patterns:
 
       skip '/favicon.ico'
       skip :assets
-      skip :xhr
       keep :forced
     end
 


### PR DESCRIPTION
The default conf in the readme did not match the actual
default conf after removal of xhr from skip.
