### PR TITLE
Update rails-dev-tweaks for Rails 4

### DIFF
--- a/rails-dev-tweaks.gemspec
+++ b/rails-dev-tweaks.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*'] + ['MIT-LICENSE', 'Rakefile', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'railties',   '~> 3.1'
-  s.add_runtime_dependency 'actionpack', '~> 3.1'
+  s.add_runtime_dependency 'railties',   '>= 3.1'
+  s.add_runtime_dependency 'actionpack', '>= 3.1'
 end


### PR DESCRIPTION
This updates the gemspec so Rails dev tweaks is compatiable with Rails 4.

But there's a bigger question- are these tweaks still relevant post Rails 3?
