### PR TITLE
Fixes performance in Rails 4.1

### DIFF
--- a/lib/rails_dev_tweaks/granular_autoload/middleware.rb
+++ b/lib/rails_dev_tweaks/granular_autoload/middleware.rb
@@ -41,8 +41,6 @@ class RailsDevTweaks::GranularAutoload::Middleware
   def reload_dependencies?
     application = Rails.application
 
-    # Rails 3.2 defines reload_dependencies? and it only reloads if reload_dependencies? returns true.
-      (!application.class.method_defined?(:reload_dependencies?) ||
-        application.send(:reload_dependencies?))
+    application.config.reload_classes_only_on_change != true || application.reloaders.map(&:updated?).any?
   end
 end


### PR DESCRIPTION
In Rails 4.1, the `reload_dependencies?` method was moved to a class. As a result, `application.class.method_defined?(:reload_dependencies?)` was always returning false and rails-dev-tweaks was reloading the code on every non-asset request. This fix will prevent that. 
