### PR TITLE
fixing deprecation for Rails 5

### DIFF
--- a/lib/rails_dev_tweaks/granular_autoload/middleware.rb
+++ b/lib/rails_dev_tweaks/granular_autoload/middleware.rb
@@ -24,8 +24,8 @@ class RailsDevTweaks::GranularAutoload::Middleware
 
       # No-op if this is the first request.  The initializers take care of that one.
       if self.class.processed_a_request? && reload_dependencies?
-        ActionDispatch::Reloader.cleanup!
-        ActionDispatch::Reloader.prepare!
+        Rails.application.reloader.reload!
+        Rails.application.reloader.prepare!
       end
       self.class.processed_a_request = true
 


### PR DESCRIPTION
Rails 5 is in it release candidate and this fix remove the deprecation messages when calling cleanup and prepare in the old way. It is not workable for Rails < 5 though and i am open for suggestion to make it work backwards.
